### PR TITLE
Mpu 109 fix crashdump print

### DIFF
--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -193,8 +193,15 @@ static bool is_recoverable(z_arch_esf_t *esf, uint64_t esr, uint64_t far,
 	return false;
 }
 
+static void thread_suspend_cb(const struct k_thread *thread, void *user_data)
+{
+	k_thread_suspend(thread);
+}
+
 void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf)
 {
+	k_thread_foreach(thread_suspend_cb, 0);
+
 	uint64_t esr = 0;
 	uint64_t elr = 0;
 	uint64_t far = 0;

--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -195,7 +195,10 @@ static bool is_recoverable(z_arch_esf_t *esf, uint64_t esr, uint64_t far,
 
 static void thread_suspend_cb(const struct k_thread *thread, void *user_data)
 {
-	k_thread_suspend(thread);
+	if(k_current_get () != thread)
+	{
+		k_thread_suspend(thread);
+	}
 }
 
 void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf)

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -24,9 +24,10 @@
 #include <zephyr/sys/arch_interface.h>
 #include "boot.h"
 
-#define SGI_SCHED_IPI	0
-#define SGI_MMCFG_IPI	1
-#define SGI_FPU_IPI	2
+#define SGI_SCHED_IPI 0
+#define SGI_MMCFG_IPI 1
+#define SGI_FPU_IPI   2
+#define SGI_FATAL_IPI 3 /* Induce fatal exception handling */
 
 struct boot_params {
 	uint64_t mpid;
@@ -178,10 +179,29 @@ void sched_ipi_handler(const void *unused)
 	z_sched_ipi();
 }
 
+void fatal_ipi_handler(const void *unused)
+{
+	ARG_UNUSED(unused);
+
+	/* This is triggered when another core crashes to bring the entire SMP
+	 * system to a stop for debugging.  
+	 */
+
+	(void)arch_irq_lock();
+	for (;;) {
+		/* Spin endlessly */
+	}
+}
+
 /* arch implementation of sched_ipi */
 void arch_sched_ipi(void)
 {
 	broadcast_ipi(SGI_SCHED_IPI);
+}
+
+void arch_fatal_ipi(void)
+{
+	broadcast_ipi(SGI_FATAL_IPI);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -241,6 +261,8 @@ static int arm64_smp_init(const struct device *dev)
 	IRQ_CONNECT(SGI_FPU_IPI, IRQ_DEFAULT_PRIORITY, flush_fpu_ipi_handler, NULL, 0);
 	irq_enable(SGI_FPU_IPI);
 #endif
+	IRQ_CONNECT(SGI_FATAL_IPI, IRQ_DEFAULT_PRIORITY, fatal_ipi_handler, NULL, 0);
+	irq_enable(SGI_FATAL_IPI);
 
 	return 0;
 }

--- a/arch/arm64/include/kernel_arch_func.h
+++ b/arch/arm64/include/kernel_arch_func.h
@@ -43,7 +43,7 @@ static inline void arch_switch(void *switch_to, void **switched_from)
 	z_arm64_context_switch(new, old);
 }
 
-extern void z_arm64_fatal_error(z_arch_esf_t *esf, unsigned int reason);
+extern void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf);
 extern void z_arm64_set_ttbr0(uintptr_t ttbr0);
 extern void z_arm64_mem_cfg_ipi(void);
 

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -459,6 +459,14 @@ static inline uint32_t arch_proc_id(void);
  * This will invoke z_sched_ipi() on other CPUs in the system.
  */
 void arch_sched_ipi(void);
+
+/**
+ * Broadcast an interrupt to all CPUs
+ *
+ * This will invoke the fatal exception handler on other CPUs in the system/
+ */
+void arch_fatal_ipi(void);
+
 #endif /* CONFIG_SMP */
 
 /** @} */


### PR DESCRIPTION
Prevent garbled crash dumps from other cores writing to shell during crash prints.  Solution freezes the other cores via inter processor interrupt messages.