### PR TITLE
MCUS-162 Remove unneeded check causing warning

### DIFF
--- a/include/zephyr/usb/usbd_msg.h
+++ b/include/zephyr/usb/usbd_msg.h
@@ -93,7 +93,7 @@ struct usbd_msg {
  */
 static inline const char *usbd_msg_type_string(const enum usbd_msg_type type)
 {
-	if (type >= 0 && type < USBD_MSG_MAX_NUMBER) {
+	if (type < USBD_MSG_MAX_NUMBER) {
 		return usbd_msg_type_list[type];
 	}
 


### PR DESCRIPTION
USB msg header introduces warning with MCUS-162 on pep. This change resolves the warning by removing the offening comparison.

## Compiler Error
`
zephyr/include/zephyr/usb/usbd_msg.h:96:18: warning: comparison is always true due to limited range of data type [-Wtype-limits]
   96 |         if (**type >= 0** && type < USBD_MSG_MAX_NUMBER) {
`