### PR TITLE
MPU-978  lto funcnames can't be sanitized

### DIFF
--- a/scripts/build/gen_symtab.py
+++ b/scripts/build/gen_symtab.py
@@ -75,7 +75,7 @@ def sanitize_func_name(name):
     if match:
         return match.group(0)
     else:
-        log.error(f"Failed to sanitize function name: {name}")
+        log.debug(f"Failed to sanitize function name: {name}")
 
     return name
 


### PR DESCRIPTION
Instead of Failing print debug warning